### PR TITLE
Route external WebView URLs through openUrl helper to avoid crash

### DIFF
--- a/app/src/main/java/io/github/drumber/kitsune/ui/webview/WebViewFragment.kt
+++ b/app/src/main/java/io/github/drumber/kitsune/ui/webview/WebViewFragment.kt
@@ -1,6 +1,5 @@
 package io.github.drumber.kitsune.ui.webview
 
-import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -143,8 +142,7 @@ class WebViewFragment : Fragment() {
             if (request?.url?.host in validKitsuHosts) {
                 return false
             }
-            val browseIntent = Intent(Intent.ACTION_VIEW, request?.url)
-            startActivity(browseIntent)
+            request?.url?.toString()?.let { openUrl(it) }
             return true
         }
 


### PR DESCRIPTION
Closes #88.

### What changes

`KitsuWebViewClient.shouldOverrideUrlLoading` in `WebViewFragment.kt` previously built an `Intent.ACTION_VIEW` and called `startActivity(browseIntent)` directly for any non-Kitsu link. If no installed app can handle the intent, that throws `ActivityNotFoundException` and the fragment crashes.

The fragment already imports the `Fragment.openUrl(url: String)` extension from `util/extensions/FragmentExtensions.kt`, which wraps the same intent launch in a `try / catch` and logs the failure. This switches the call site to that helper.

```diff
 override fun shouldOverrideUrlLoading(
     view: WebView?,
     request: WebResourceRequest?
 ): Boolean {
     if (request?.url?.host in validKitsuHosts) {
         return false
     }
-    val browseIntent = Intent(Intent.ACTION_VIEW, request?.url)
-    startActivity(browseIntent)
+    request?.url?.toString()?.let { openUrl(it) }
     return true
 }
```

The now-unused `android.content.Intent` import is dropped as well.
