### PR TITLE
Open external links safely in the sign-in WebView

### DIFF
--- a/app/src/main/java/io/github/drumber/kitsune/ui/webview/WebViewFragment.kt
+++ b/app/src/main/java/io/github/drumber/kitsune/ui/webview/WebViewFragment.kt
@@ -1,6 +1,5 @@
 package io.github.drumber.kitsune.ui.webview
 
-import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -143,8 +142,7 @@ class WebViewFragment : Fragment() {
             if (request?.url?.host in validKitsuHosts) {
                 return false
             }
-            val browseIntent = Intent(Intent.ACTION_VIEW, request?.url)
-            startActivity(browseIntent)
+            request?.url?.let { openUrl(it.toString()) }
             return true
         }
 


### PR DESCRIPTION
### What

`WebViewFragment.shouldOverrideUrlLoading` forwards every off-Kitsu link to an external app with a raw `startActivity(Intent(Intent.ACTION_VIEW, ...))`. When no installed app can handle the URI that call raises `ActivityNotFoundException` and the Activity crashes.

This routes the link through the existing `Fragment.openUrl` helper, which already wraps the launch in a try/catch and logs the failure instead of taking down the screen. It keeps the behaviour identical for links that do resolve.

### Change

```diff
-import android.content.Intent
 import android.graphics.Bitmap
```

```diff
-            val browseIntent = Intent(Intent.ACTION_VIEW, request?.url)
-            startActivity(browseIntent)
+            request?.url?.let { openUrl(it.toString()) }
             return true
```

The `Intent` import is removed because the method no longer references it directly.

Closes #90
